### PR TITLE
Fix README to not confuse new git users about upstream 

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ $ cd simplefolio
 
 # Remove current origin repository
 $ git remote remove origin
+$ git remote add origin git@github.com:<your github username>/simplefolio.git
 ```
 
 Then you can install the dependencies either using NPM or Yarn:


### PR DESCRIPTION
Was helping a friend who was using your project and he got mixed up because the remote origin was removed but never replaced, so he didn't know why he couldn't push upstream