### PR TITLE
Remove extra closing a tag

### DIFF
--- a/src/template.html
+++ b/src/template.html
@@ -262,7 +262,6 @@
         <!-- If you give me some credit, will be huge for me :) -->
         <p class="footer__text">
           © 2020 - Template developed by <a href="https://github.com/cobidev" target="_blank">Jacobo Martínez</a>
-          </a>
         </p>
 
         <!-- Remove this paragraph once you setup your custom portfolio -->


### PR DESCRIPTION
Remove extra closing `a` tag in `footer__text` paragraph